### PR TITLE
Misprint

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -14,6 +14,6 @@
 - name: Databases | Add hstore to the databases with the requirement
   sudo: yes
   sudo_user: "{{postgresql_admin_user}}"
-  shell: "psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS hstore;"
+  shell: "psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
   with_items: postgresql_databases
   when: "item.hstore is defined and item.hstore == 'yes'"


### PR DESCRIPTION
Fixed:

```
TASK: [PostgreSQL | Databases | Add hstore to the databases with the requirement] *** 
fatal: [rosa-build-1] => error parsing argument string 'psql {{ item.name }} -c 'CREATE EXTENSION IF NOT EXISTS hstore;', try quoting the entire line.

FATAL: all hosts have already failed -- aborting

```
