### PR TITLE
Changed the force restart on pg conf change to use notify/handler (idempotent)

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -37,6 +37,8 @@
     owner: "{{postgresql_admin_user}}"
     group: "{{postgresql_admin_user}}"
     mode: 0640
+  notify:
+    - restart postgresql
 
 - name: Configure | Update configuration - (postgresql.conf)
   template:
@@ -45,8 +47,5 @@
     owner: "{{postgresql_admin_user}}"
     group: "{{postgresql_admin_user}}"
     mode: 0640
-
-- name: Reload The PostgreSQL Configuration
-  command: service postgresql{{ join_char | default("-")}}{{ postgresql_version }} restart
-
-
+  notify:
+    - restart postgresql


### PR DESCRIPTION
At the end of `configuration.yml`, postgres was being force-restarted, regardless of whether there were config changes or not, meaning that the role is not idempotent, i.e. run it twice, and that will always come up as changed.

I have switched this to use a notify so that the restart only occurs if there are changed configuration files.

Does that sound OK with you? Also, thanks for the role, really useful :)