### PR TITLE
conditional krb_srvname for postgres 9.4

### DIFF
--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -79,7 +79,7 @@ db_user_namespace       = {{'on' if postgresql_db_user_namespace else 'off'}}
 
 # Kerberos and GSSAPI
 krb_server_keyfile = '{{postgresql_krb_server_keyfile}}'
-krb_srvname        = '{{postgresql_krb_srvname}}'
+{% if postgresql_version <= 9.3 %}krb_srvname        = '{{postgresql_krb_srvname}}'{% endif %}
 krb_caseins_users  = {{'on' if postgresql_db_user_namespace else 'off'}}
 
 # TCP Keepalives, 0 selects the system default


### PR DESCRIPTION
Me again!

When using `postgresql_version: 9.4` I came across the error of:
```
NOTIFIED: [patrik.uytterhoeven.PostgreSQL-For-RHEL6x | restart postgresql] ****
failed: [192.168.50.11] => {"failed": true}
msg: Job for postgresql-9.4.service failed. See 'systemctl status postgresql-9.4.service' and 'journalctl -xn' for details.
```
Which is:
```
[vagrant@postgres ~]$ sudo systemctl status postgresql-9.4.service
postgresql-9.4.service - PostgreSQL 9.4 database server
   Loaded: loaded (/usr/lib/systemd/system/postgresql-9.4.service; enabled)
   Active: failed (Result: exit-code) since Wed 2015-02-25 14:28:46 UTC; 56s ago
  Process: 13462 ExecStop=/usr/pgsql-9.4/bin/pg_ctl stop -D ${PGDATA} -s -m fast (code=exited, status=0/SUCCESS)
  Process: 13473 ExecStart=/usr/pgsql-9.4/bin/pg_ctl start -D ${PGDATA} -s -w -t 300 (code=exited, status=1/FAILURE)
  Process: 13468 ExecStartPre=/usr/pgsql-9.4/bin/postgresql94-check-db-dir ${PGDATA} (code=exited, status=0/SUCCESS)
 Main PID: 13325 (code=exited, status=0/SUCCESS)

Feb 25 14:28:41 postgres systemd[1]: Starting PostgreSQL 9.4 database server...
Feb 25 14:28:41 postgres pg_ctl[13473]: LOG:  unrecognized configuration parameter "krb_srvname" in file "/var/lib/pgsql/9....line 82
Feb 25 14:28:41 postgres pg_ctl[13473]: FATAL:  configuration file "/var/lib/pgsql/9.4/data/postgresql.conf" contains errors
Feb 25 14:28:46 postgres pg_ctl[13473]: pg_ctl: could not start server
Feb 25 14:28:46 postgres pg_ctl[13473]: Examine the log output.
Feb 25 14:28:46 postgres systemd[1]: postgresql-9.4.service: control process exited, code=exited status=1
Feb 25 14:28:46 postgres systemd[1]: Failed to start PostgreSQL 9.4 database server.
Feb 25 14:28:46 postgres systemd[1]: Unit postgresql-9.4.service entered failed state.
Hint: Some lines were ellipsized, use -l to show in full.
```

I found the fix via https://github.com/sbecker/ansible-postgresql-complete/commit/fde4789e7016dc98bc045b38ad20b8e127ce7d77 (a PR against a similar galaxy role for the Debian family). It appears that `krb_srvname` has been deprecated in Postgres 9.4. I can't find anything specifically mentioning it, however looking at the docs for 9.3, then the docs for 9.4, it is certainly missing:
* [9.3](http://www.postgresql.org/docs/9.3/static/runtime-config-connection.html)
* [9.4](http://www.postgresql.org/docs/9.4/static/runtime-config-connection.html)