### PR TITLE
Prevent postgresql passwords being logged by Ansible

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -9,6 +9,7 @@
     role_attr_flags: "{{item.role_attr_flags | default('LOGIN')}}"
   with_items: postgresql_users
   when: postgresql_users|length > 0
+  no_log: True
 
 - name: PostgreSQL | Update the user privileges
   postgresql_user:
@@ -19,3 +20,4 @@
     login_host: "{{item.host | default('localhost')}}"
   with_items: postgresql_user_privileges
   when: postgresql_users|length > 0
+  no_log: True


### PR DESCRIPTION
Don't print out the postgresql user dictionary
by passing `no_log` when using it with `with_items`.

Although `postgresql_user` hides its password value,
how Ansible logs loops (by printing each item in turn)
causes the password to be logged.