### PR TITLE
Allow user passwords to be stored encrypted

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -7,6 +7,7 @@
     state: present
     login_host: "{{item.host | default('localhost')}}"
     role_attr_flags: "{{item.role_attr_flags | default('LOGIN')}}"
+    encrypted: "{{item.encrypted | default('no')}}"
   with_items: postgresql_users
   when: postgresql_users|length > 0
 
@@ -17,5 +18,6 @@
     priv: "{{item.priv | default('ALL')}}"
     state: present
     login_host: "{{item.host | default('localhost')}}"
+    encrypted: "{{item.encrypted | default('no')}}"
   with_items: postgresql_user_privileges
   when: postgresql_users|length > 0


### PR DESCRIPTION
The postgresql_user module allows passwords to be stored
encrypted (whether or not they are passed encrypted).

The README suggests that there is an encrypted
parameter, so this makes the code match the docs