### PR TITLE
Start postgresql service after config changes

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -25,11 +25,6 @@
   command: /usr/pgsql-{{ postgresql_version }}/bin/postgresql{{ postgresql_version|replace('.','') }}-setup initdb
   when: data_dir.stat.exists == false and ansible_distribution_major_version == '7'
 
-- name: Ensure PostgreSQL is running
-  service: name=postgresql{{ join_char | default("-")}}{{ postgresql_version }} state=started enabled=yes
-  notify:
-    - restart postgresql
-
 - name: Configure | Update configuration - (pg_hba.conf)
   template:
     src: pg_hba.conf.j2
@@ -52,3 +47,8 @@
 
 - name: Configure | DB restart should happen now if required
   meta: flush_handlers
+
+# Ensure postgresql is started if it didn't get restarted
+# (i.e. it was down and no config changes since)
+- name: Ensure PostgreSQL is running
+  service: name=postgresql{{ join_char | default("-")}}{{ postgresql_version }} state=started enabled=yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,3 +13,5 @@
   with_items:
     - postgresql{{ postgresql_version|replace('.', '') }}-server
     - postgresql{{ postgresql_version|replace('.', '') }}-contrib
+  notify:
+    - restart postgresql


### PR DESCRIPTION
Move check for state=started to after configuration changes

This allows for:
* no configuration changes are made but the service was down
* configuration was broken so service won't start until config
  is fixed