### PR TITLE
Fix default value for role variables …

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,22 +18,22 @@ postgresql_cluster_name: "data"
 postgresql_cluster_reset: false          # true or false
 
 
-# List of database to be created (optional)
-postgresql_databases: #[]                # Remove [] When adding a database and uncomment name, hstore
-              - name:
-                hstore: yes              # flag to install the hstore extensions on this database (yes/no)
+# List of databases to be created (optional)
+postgresql_databases: []                # Override when needed, usage as shown below
+        #      - name: dbname           # Database
+        #        hstore: yes            # flag to install the hstore extensions on this database (yes/no)
 
 # List of users to be created (optional)
-postgresql_users: #[]                    # Remove [] When adding a database and uncomment name, pass, encrypted
-              - name:
-                pass:
-                encrypted: no            # Is password already encrypted (yes/no)
+postgresql_users: []                    # Override when needed, usage as shown below
+        #      - name: dbuser           # Username
+        #        pass: passw0rd         # User password
+        #        encrypted: no          # Is password already encrypted (yes/no)
 
 # List of user privileges to be applied (optional)
-postgresql_user_privileges: #[]          # Remove [] When adding a database and uncomment name, db, priv
-              - name:                    # Username
-                db:                      # Database
-                priv: "ALL"              # Privilege string format: example: INSERT,UPDATE/table:SELECT/anothertable:ALL
+postgresql_user_privileges: []          # Override when needed, usage as shown below
+        #      - name: dbuser           # Username
+        #        db: dbname             # Database
+        #        priv: "ALL"            # Privilege string format: example: INSERT,UPDATE/table:SELECT/anothertable:ALL
 
 # pg_hba.conf
 postgresql_pg_hba_default:


### PR DESCRIPTION
… ``postgresql_databases``, ``postgresql_users`` and ``postgresql_user_privileges``.

The default values should be ``[]`` for these variables, otherwise we get the following errors:

```
TASK: [patrik.uytterhoeven.PostgreSQL-For-RHEL6x | Databases | Make sure the PostgreSQL databases are present] *** 
failed: [app] => (item={'name': None, 'hstore': True}) => {"failed": true, "item": {"hstore": true, "name": null}}
msg: Identifier name unspecified or unquoted trailing dot
```

```
TASK: [patrik.uytterhoeven.PostgreSQL-For-RHEL6x | PostgreSQL | Make sure the PostgreSQL users are present] *** 
failed: [app] => {"censored": "results hidden due to no_log parameter", "failed": true}
```

This issue was introduced at [this commit](https://github.com/Open-Future-Belgium/PostgreSQL/commit/8aa216a39b5ddb926f5de5914eb117f1d21df11e) I believe.