### PR TITLE
Enable non-default port and data dir on RHEL7

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,4 @@
 # Config file for PostgreSQL
-
 - name: Config | Stop the Cluster
   command: service postgresql{{ join_char | default("-")}}{{ postgresql_version }} stop
   when: postgresql_cluster_reset
@@ -7,6 +6,16 @@
 - name: Config | Reset the cluster - drop the existing one
   shell: rm -rf {{ postgresql_conf_directory }}
   when: postgresql_cluster_reset
+
+- name: Install service file on Centos/Rhel 7
+  template: src="postgresql.service.j2" dest="/etc/systemd/system/postgresql{{ join_char | default("-")}}{{ postgresql_version }}.service"
+  when: ansible_distribution_major_version == '7'
+  register: servicefile
+
+  # Can't use flush_handlers here as it might trigger a postgresql restart too early
+- name: reload systemctl if service file changed
+  command: systemctl daemon-reload
+  when: servicefile.changed
 
 - name: Config | Reset the cluster - create a new one (with specified encoding and locale)
   command: service postgresql{{ join_char | default("-")}}{{ postgresql_version }} initdb {{postgresql_cluster_name}}

--- a/templates/postgresql.service.j2
+++ b/templates/postgresql.service.j2
@@ -1,0 +1,4 @@
+.include /lib/systemd/system/postgresql-{{postgresql_version}}.service
+[Service]
+Environment=PGDATA={{postgresql_data_directory}}
+Environment=PGPORT={{postgresql_port}}


### PR DESCRIPTION
postgresql uses systemd for its configuration and
adding the postgresql.service file appears to be
the correct way to set the data directory