### PR TITLE
Remove /var/run from unix sockets fixes #26

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,7 +77,7 @@ postgresql_superuser_reserved_connections: 3
 
 postgresql_unix_socket_directories:
   - /tmp
-  - /var/run/postgresql/
+
 postgresql_unix_socket_group: ''
 postgresql_unix_socket_permissions: '0777' # begin with 0 to use octal notation
 


### PR DESCRIPTION
Just making sure that this role compiles by default. See issue #26