### PR TITLE
Register tmpfiles.d config on RHEL7

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,6 +16,14 @@
   when: ansible_distribution_major_version == '7'
   register: servicefile
 
+- name: create /var/run/postgresql tmpfiles.d entry
+  lineinfile: dest=/etc/tmpfiles.d/postgresql93.conf line="D /var/run/postgresql 0755 postgres postgres -" create=yes
+  when: ansible_distribution_major_version == '7'
+
+- name: restart tmpfiles service
+  command: systemd-tmpfiles --create
+  when: ansible_distribution_major_version == '7'
+
   # Can't use flush_handlers here as it might trigger a postgresql restart too early
 - name: reload systemctl if service file changed
   command: systemctl daemon-reload


### PR DESCRIPTION
RHEL7 uses systemd-tmpfiles to populate /var/run/.  This is necessary
for /var/run/postgresql/ to exist so postgresql startup succeeds.