### PR TITLE
Allow more database privileges capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CentOS/Rhel 6.x & 7.x / Amazon Linux 2014.09
 
 Updated
 -------
-19/7/2015
+03/08/2015
 
 Role Variables
 --------------
@@ -42,7 +42,23 @@ postgresql_user_privileges:
   - name: john         # user name
     db: foobar         # database
     priv: "ALL"        # privilege string format: example: INSERT,UPDATE/table:SELECT/anothertable:ALL
+                       #   N.B. ALL only provides all *database* privileges, but
+                       #   no table privileges
+
+# List of object privileges to be applied
+postgresql_user_object_privileges:
+  - name: john             # user name
+    db: foobar             # database
+    type: table            # type of db object on which to set privilege
+    priv: ALL              # list of privileges (e.g. INSERT,SELECT)
+    objs: 'ALL_IN_SCHEMA'  # list of db objects on which to set privilege
+  - name: john             # user name
+    db: foobar             # database
+    type: sequence         # type of db object on which to set privilege
+    priv: ALL              # list of privileges (e.g. INSERT,SELECT)
+    objs: 'ALL_IN_SCHEMA'  # list of db objects on which to set privilege
 ```
+
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,14 @@ postgresql_user_privileges: []          # Override when needed, usage as shown b
         #        db: dbname             # Database
         #        priv: "ALL"            # Privilege string format: example: INSERT,UPDATE/table:SELECT/anothertable:ALL
 
+# List of user object privileges to be applied (optional)
+postgresql_user_object_privileges: []   # Remove [] When adding a database and uncomment name, db, priv
+#              - name: otheruser        # Username
+#                db: dbname             # Database
+#                type: table            # type of db object on which to set privilege
+#                priv: ALL              # list of privileges (e.g. INSERT,SELECT)
+#                objs: 'ALL_IN_SCHEMA'  # list of db objects on which to set privilege
+
 # pg_hba.conf
 postgresql_pg_hba_default:
   - { type: local, database: all, user: '{{ postgresql_admin_user }}', address: '', method: '{{ socket_postgresql_default_auth_method }}', comment: '' }

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -12,14 +12,25 @@
   when: postgresql_users|length > 0
   no_log: True
 
-- name: PostgreSQL | Update the user privileges
+- name: PostgreSQL | Update the users database privileges
   postgresql_user:
     name: "{{item.name}}"
     db: "{{item.db}}"
     priv: "{{item.priv | default('ALL')}}"
     state: present
     login_host: "{{item.host | default('localhost')}}"
-    encrypted: "{{item.encrypted | default('no')}}"
   with_items: postgresql_user_privileges
-  when: postgresql_users|length > 0
-  no_log: True
+  when: postgresql_user_privileges|length > 0
+
+- name: PostgreSQL | Update the users object privileges
+  postgresql_privs:
+    role: "{{item.name}}"
+    db: "{{item.db}}"
+    priv: "{{item.priv | default('ALL')}}"
+    state: present
+    schema: "{{item.schema|default('public')}}"
+    objs: "{{item.objs|default('')}}"
+    type: "{{item.type|default('')}}"
+    login_host: "{{item.host | default('localhost')}}"
+  with_items: postgresql_user_object_privileges
+  when: postgresql_user_object_privileges|length > 0


### PR DESCRIPTION
Allow the grant of table (and other object) level
privileges.

This allows things like granting select privileges to
all tables in a database to a specific user