### PR TITLE
Fixes #26 #33 #32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,41 @@
+---
+driver:
+  name: vagrant
+  network:
+    - ["public_network"]
+
+provisioner:
+  name: ansible_playbook
+  playbook: tests/test.yml
+  ansible_diff: true
+  hosts: localhost
+  require_ruby_for_busser: false
+
+platforms:
+  - name: centos-7.1
+    driver_config:
+      box: chef/centos-7.1
+    provisioner:
+      ansible_yum_repo: "http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+
+  - name: centos-6.6
+    driver_config:
+      box: chef/centos-6.6
+    provisioner:
+      ansible_yum_repo: "http://mirror.logol.ru/epel/6/x86_64/epel-release-6-8.noarch.rpm"
+
+suites:
+  - name: pg-9.3-tmp
+    provisioner:
+      attributes:
+        extra_vars:
+            postgresql_unix_socket_directories:
+              - /tmp
+
+  - name: pg-9.4-tmp
+    provisioner:
+      attributes:
+        extra_vars:
+            postgresql_version: 9.4
+            postgresql_unix_socket_directories:
+              - /tmp

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,7 +85,7 @@ postgresql_superuser_reserved_connections: 3
 
 postgresql_unix_socket_directories:
   - /tmp
-  - /var/run/postgresql/
+
 postgresql_unix_socket_group: ''
 postgresql_unix_socket_permissions: '0777' # begin with 0 to use octal notation
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -39,7 +39,7 @@
   register: data_dir
 
 - name: Initialise Postgresql Database if it is not
-  command: service postgresql{{ join_char | default("-")}}{{ postgresql_version }} initdb {{postgresql_cluster_name}}
+  command: service postgresql{{ join_char | default("-")}}{{ postgresql_version }} initdb
   when: data_dir.stat.exists == false and ansible_distribution_major_version == '6'
 
 - name: Initialise Postgresql Database on Centos/Rhel 7 if it is not

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,4 @@
+---
+- hosts: localhost
+  roles:
+    - { role: PostgreSQL }


### PR DESCRIPTION
This PR fixes multiple issues with setting up postgresql with CentOS6 AND it doesn't not break anything for CentOS7.

Pretty please take a look at this PR and testing support it provides.
just install test-kitchen with
```
gem install test-kitchen
```
and run
```
kitchen setup all -p -c 4
```
this will provision 4 vms:
- 2 with 9.3
- and 2 with 9.4
```
