### PR TITLE
use single quotes to avoid escaping double quotes

### DIFF
--- a/tasks/repo-exclude-centos.yml
+++ b/tasks/repo-exclude-centos.yml
@@ -12,13 +12,13 @@
   ini_file: dest=/etc/yum.repos.d/CentOS-Base.repo
         section=base
         option=exclude
-        value="{{ (ansible_local.baserepo.base.exclude | default("") | replace("postgresql*", "") | trim ~ " postgresql* ") | trim }}"
+        value='{{ (ansible_local.baserepo.base.exclude | default("") | replace("postgresql*", "") | trim ~ " postgresql* ") | trim }}'
         backup=yes
 
 - name: Install | CentOS | Exclude packages, updates section
   ini_file: dest=/etc/yum.repos.d/CentOS-Base.repo
         section=updates
         option=exclude
-        value="{{ (ansible_local.baserepo.updates.exclude | default("") | replace("postgresql*", "") | trim ~ " postgresql* ") | trim }}"
+        value='{{ (ansible_local.baserepo.updates.exclude | default("") | replace("postgresql*", "") | trim ~ " postgresql* ") | trim }}'
         backup=yes
 


### PR DESCRIPTION
The unescaped double quotes in these task parameters causes the tasks to fail when using Ansible 2.X. Using single quotes for the parameters works around the problem handily.