### PR TITLE
Add feature to allow role to work on nodes that are CentOS disguised as RedHat

### DIFF
--- a/tasks/repo-exclude-amazon.yml
+++ b/tasks/repo-exclude-amazon.yml
@@ -13,16 +13,21 @@
   when: repo_fact_file|changed or repo2_fact_file|changed
 
 - name: Install | Amazon | Exclude packages from main repo
-  ini_file: dest=/etc/yum.repos.d/amzn-main.repo
-        section=amzn-main
-        option=exclude
-        value="{{ (ansible_local['amznmain']['amzn-main']['exclude'] | default("") | replace("postgresql*", "") | trim ~ " postgresql*") | trim }}"
-        backup=yes
+  ini_file:
+    dest: /etc/yum.repos.d/amzn-main.repo
+    section: amzn-main
+    option: exclude
+    value: >
+      "{{ (ansible_local['amznmain']['amzn-main']['exclude'] |
+      default('') | replace('postgresql*', '') | trim ~ ' postgresql*') | trim }}"
+    backup: yes
 
 - name: Install | Amazon | Exclude packages from updates repo
-  ini_file: dest=/etc/yum.repos.d/amzn-updates.repo
-        section=amzn-updates
-        option=exclude
-        value="{{ (ansible_local['amznupdates']['amzn-updates']['exclude'] | default("") | replace("postgresql*", "") | trim ~ " postgresql* ") | trim }}"
-        backup=yes
-
+  ini_file:
+    dest: /etc/yum.repos.d/amzn-updates.repo
+    section: amzn-updates
+    option: exclude
+    value: >
+      "{{ (ansible_local['amznupdates']['amzn-updates']['exclude'] |
+      default('') | replace('postgresql*', '') | trim ~ ' postgresql* ') | trim }}"
+    backup: yes

--- a/tasks/repo-exclude-centos.yml
+++ b/tasks/repo-exclude-centos.yml
@@ -9,16 +9,21 @@
   when: repo_fact_file|changed
 
 - name: Install | CentOS | Exclude packages, base section
-  ini_file: dest=/etc/yum.repos.d/CentOS-Base.repo
-        section=base
-        option=exclude
-        value="{{ (ansible_local.baserepo.base.exclude | default("") | replace("postgresql*", "") | trim ~ " postgresql* ") | trim }}"
-        backup=yes
+  ini_file:
+    dest: /etc/yum.repos.d/CentOS-Base.repo
+    section: base
+    option: exclude
+    value: >
+      "{{ (ansible_local.baserepo.base.exclude | default('') |
+      replace('postgresql*', '') | trim ~ ' postgresql* ') | trim }}"
+    backup: yes
 
 - name: Install | CentOS | Exclude packages, updates section
-  ini_file: dest=/etc/yum.repos.d/CentOS-Base.repo
-        section=updates
-        option=exclude
-        value="{{ (ansible_local.baserepo.updates.exclude | default("") | replace("postgresql*", "") | trim ~ " postgresql* ") | trim }}"
-        backup=yes
-
+  ini_file:
+    dest: /etc/yum.repos.d/CentOS-Base.repo
+    section: updates
+    option: exclude
+    value: >
+      "{{ (ansible_local.baserepo.updates.exclude | default('') |
+      replace('postgresql*', '') | trim ~ ' postgresql* ') | trim }}"
+    backup: yes

--- a/tasks/repo-exclude-rhel.yml
+++ b/tasks/repo-exclude-rhel.yml
@@ -1,17 +1,31 @@
 # Exclude postgresql* on RHEL
 
-- name: Install | RHEL | Create symlink for repo fact gathering
-  file: src=/etc/yum/pluginconf.d/rhnplugin.conf dest=/etc/ansible/facts.d/rhnplugin.fact state=link
-  register: repo_fact_file
+- name: check rhnplugin.conf exists
+  stat: path=/etc/yum/pluginconf.d/rhnplugin.conf
+  register: rhnplugin_conf
 
-- name: Install | RHEL | Gather repository facts
-  setup: filter=ansible_local
-  when: repo_fact_file|changed
+# Real Redhat
+- block:
+  - name: Install | RHEL | Create symlink for repo fact gathering
+    file: src=/etc/yum/pluginconf.d/rhnplugin.conf dest=/etc/ansible/facts.d/rhnplugin.fact state=link
+    register: repo_fact_file
 
-- name: Install | RHEL | Exclude packages
-  ini_file: dest=/etc/yum/pluginconf.d/rhnplugin.conf
-        section=main
-        option=exclude
-        value="{{ (ansible_local.rhnplugin.main.exclude | default("") | replace("postgresql*", "") | trim ~ " postgresql* ") | trim }}"
-        backup=yes
+  - name: Install | RHEL | Gather repository facts
+    setup: filter=ansible_local
+    when: repo_fact_file|changed
 
+  - name: Install | RHEL | Exclude packages
+    ini_file:
+      dest: /etc/yum/pluginconf.d/rhnplugin.conf
+      section: main
+      option: exclude
+      value: >
+        "{{ (ansible_local.baserepo.base.exclude | default('') |
+        replace('postgresql*', '') | trim ~ ' postgresql* ') | trim }}"
+      backup: yes
+  when: rhnplugin_conf.stat is defined and rhnplugin_conf.stat.isfile
+
+# CentOS with modified /etc/redhat-release something like 'Red Hat Enterprise Linux Server release 7.2 (Maipo)'
+- name: Detected CentOS hiding as RedHat
+  include: repo-exclude-centos.yml
+  when: rhnplugin_conf.stat is defined and rhnplugin_conf.stat.exists == false


### PR DESCRIPTION
Due to current VMware Customizations not working with CentOS, a common fix is to modify the CentOS file `/etc/redhat-release` to read something like `Red Hat Enterprise Linux Server release 7.2 (Maipo)`.  Ansible then is also fooled, which is a shame really.

This commit checks that the `rhnplugin.conf` does not exists, which would only exist on a true RedHat instance. If it does not, the `repo-exclude-rhel.yml` file is included in the play.

The commit also addresses the use of single quotes because errors were thrown on ansible >=2.0.0 when embedded double quotes were not escaped.  Additionally some lines have been shortened to aid readability.