### PR TITLE
use single quotes to avoid escaping double quotes

### DIFF
--- a/tasks/repo-exclude-rhel.yml
+++ b/tasks/repo-exclude-rhel.yml
@@ -12,6 +12,6 @@
   ini_file: dest=/etc/yum/pluginconf.d/rhnplugin.conf
         section=main
         option=exclude
-        value="{{ (ansible_local.rhnplugin.main.exclude | default("") | replace("postgresql*", "") | trim ~ " postgresql* ") | trim }}"
+        value='{{ (ansible_local.rhnplugin.main.exclude | default("") | replace("postgresql*", "") | trim ~ " postgresql* ") | trim }}'
         backup=yes
 


### PR DESCRIPTION
The unescaped double quotes in these task parameters causes the tasks to fail when using Ansible 2.X.

This is a similar to the problem fixed by #45 for CentOS.