### PR TITLE
Change minimum ansible version to 2.0

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: MIT
-  min_ansible_version: 1.4
+  min_ansible_version: 2.0
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your


### PR DESCRIPTION
Now that the PR #51 (that added usage of `block`) is merged the minimum Ansible version required for this role is 2.0.

For reference: http://docs.ansible.com/ansible/playbooks_blocks.html

@Trikke76 Not sure if you want change the minimum ansible version or just remove the usage of `block`. I can do another PR to remove it if you want to.

PS - If we keep the change of the `min_ansible_version` I think it would be good to tag a version from the latest commit before the merge of PR #51.