### PR TITLE
Fix defaults for client_encoding

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -553,7 +553,7 @@ postgresql_timezone:           UTC
 postgresql_timezone_abbreviations: Default
 
 postgresql_extra_float_digits: 0          # min -15, max 3
-postgresql_client_encoding:    sql_ascii  # 'sql_ascii' actually defaults to database encoding
+postgresql_client_encoding: false         # 'sql_ascii' actually defaults to database encoding
 
 # These settings are initialized by initdb, but they can be changed.
 

--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -380,7 +380,11 @@ timezone                   = '{{postgresql_timezone}}'
 timezone_abbreviations     = '{{postgresql_timezone_abbreviations}}'
 
 extra_float_digits         = {{postgresql_extra_float_digits}}
-client_encoding            = {{postgresql_client_encoding}}
+{% if not postgresql_client_encoding %}
+#client_encoding = sql_ascii        # actually, defaults to database
+{% else %}
+client_encoding = {{postgresql_client_encoding}}        # actually, defaults to database
+{% endif %}
 
 lc_messages                = '{{postgresql_lc_messages}}'
 lc_monetary                = '{{postgresql_lc_monetary}}'


### PR DESCRIPTION
Current default
```
postgresql_client_encoding:    sql_ascii
```
fails for my use case.
I'd like the role to generate default as it is delivered by postgresql rpm.
