### PR TITLE
Fix psql_repo url for ansible 1.x

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ postgresql_encoding: 'UTF-8'
 postgresql_locale: 'en_US.UTF-8'
 
 # PostgreSQL Repo File
-pgsql_repo: "http://yum.postgresql.org/{{ postgresql_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-x86_64/pgdg-redhat{{ postgresql_version|replace('.', '') }}-{{ postgresql_version }}-1.noarch.rpm"
+pgsql_repo: "http://yum.postgresql.org/{{ postgresql_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-x86_64/pgdg-redhat{{ postgresql_version|replace('.', '') }}-{{ postgresql_version }}-3.noarch.rpm"
 
 postgresql_admin_user: "postgres"
 socket_postgresql_default_auth_method: "trust"


### PR DESCRIPTION
This is a backport of e427593f34ddcd791d2ddeff01a2c8d2c7ff5fd2 which updates the psql_repo.