### PR TITLE
replace deprecated sudo/sudo_user with become/become_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Example Playbook
 # file: localrepo.yml
 - hosts: vagrant
   user: vagrant
-  sudo: yes
-  sudo_user: root
+  become: yes
+  become_user: root
   roles:
     - PostgreSQL
 ```
@@ -91,7 +91,7 @@ Amazon Linux Example Playbook
 ```yaml
 - hosts: tag_your_tag_name
   remote_user: ec2-user
-  sudo: yes
+  become: yes
   roles:
     - { role: PostgreSQL,
         postgresql_version: 93,

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: MIT
-  min_ansible_version: 1.4
+  min_ansible_version: 1.9
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your
@@ -120,4 +120,3 @@ dependencies: []
   # dependencies available via galaxy should be listed here.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
-

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -12,8 +12,8 @@
   when: postgresql_databases|length > 0
 
 - name: Databases | Add hstore to the databases with the requirement
-  sudo: yes
-  sudo_user: "{{postgresql_admin_user}}"
+  become: yes
+  become_user: "{{postgresql_admin_user}}"
   shell: "psql {{item.name}} -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
   with_items: postgresql_databases
   when: "item.hstore is defined and item.hstore == 'yes'"


### PR DESCRIPTION
This replaces `sudo` and `sudo_user` (which have been deprecated) with `become` and `become_user`