### PR TITLE
Updated postgres.conf template synchronous_commit property

### DIFF
--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -150,7 +150,7 @@ effective_io_concurrency = {{postgresql_effective_io_concurrency}}
 wal_level = {{postgresql_wal_level}}
 fsync = {{'on' if postgresql_fsync else 'off'}}
 
-synchronous_commit = {{'on' if postgresql_synchronous_commit else 'off'}}
+synchronous_commit = {{postgresql_synchronous_commit}}
 
 wal_sync_method = {{postgresql_wal_sync_method}}
 


### PR DESCRIPTION
Since the postgres docs mention other values than on & off, and so do the defaults in this ansible role, we should allow those values into the template. Was trying this and wondered why my value of `local` wasn't getting populated.